### PR TITLE
fix: generate dynamic copyright year in the footer

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -429,7 +429,7 @@
 
         <div class="mt-16 border-t border-gray-100 pt-8">
           <p class="text-center text-xs/relaxed text-gray-500">
-            © Company 2022. All rights reserved.
+            © Company <script>document.write(new Date().getFullYear())</script>. All rights reserved.
 
             <br />
 


### PR DESCRIPTION
## Related Issue

Issue#8

## Description

Fix the hard coded copyright year in the footer to generate dynamically

## Screenshots

![Screenshot from 2024-01-04 10-48-45](https://github.com/dakshsinghrathore/Brighter-Beginnings/assets/134488182/16bd4929-5069-4d36-92ae-1c7216b781b0)
