### PR TITLE
Fixed menu-items overflowing underline

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -117,32 +117,32 @@
       </header>
       <div
         id="headerDropList"
-        class="w-1/3 sm:w-64 min-w-min h-36 right-8 rounded-xl rounded-tr-none fixed top-14 z-50 border bg-transparent backdrop-blur-sm md:hidden"
+        class="w-1/3 sm:w-64 min-w-min h-36 right-8 rounded-xl rounded-tr-none fixed top-14 z-50 border bg-transparent backdrop-blur-sm md:hidden overflow-hidden"
       >
         <ul class="h-full flex-col justify-evenly">
           <li
-            class="h-1/3 border-0 border-b border-b-gray-700 text-center text-xl"
+            class="h-1/3 border-0 border-b border-b-gray-700 text-center text-xl hover:text-gray-500/75"
           >
             <a
-              class="text-gray-500 transition hover:text-gray-500/75 h-full w-full flex justify-center items-center"
+              class="text-gray-500 transition h-full w-full flex justify-center items-center"
               href="about.html"
             >
               About
             </a>
           </li>
           <li
-            class="h-1/3 border-0 border-b border-b-gray-700 text-center text-xl"
+            class="h-1/3 border-0 border-b border-b-gray-700 text-center text-xl hover:text-gray-500/75"
           >
             <a
-              class="text-gray-500 transition hover:text-gray-500/75 h-full w-full flex justify-center items-center"
+              class="text-gray-500 transition h-full w-full flex justify-center items-center"
               href="services.html"
             >
               Services
             </a>
           </li>
-          <li class="h-1/3 text-center text-xl">
+          <li class="h-1/3 text-center text-xl hover:text-gray-500/75">
             <a
-              class="text-gray-500 transition hover:text-gray-500/75 h-full w-full flex justify-center items-center"
+              class="text-gray-500 transition h-full w-full flex justify-center items-center"
               href="blog.html"
             >
               Blog

--- a/dist/style.css
+++ b/dist/style.css
@@ -1970,12 +1970,13 @@ select {
 }
 .hover\:text-gray-500\/75::after {
   content: "";
-  width: 150%;
+  display: block;
+  width: 100%;
   background-color: #fff;
   height: 2px;
-  left: -25%;
-  position: absolute;
-  bottom: -6px;
+  /* left: -25%; */
+  position: relative;
+  bottom: 1px;
   transform: scaleX(0);
   transition: transform 0.2s linear;
 }


### PR DESCRIPTION
## Related Issue
Menu-items underline was not responsive
## Description
Menu-items underline overflowing in small devices. 
To fixed this issue i have remove underline from` <a>` tag to its parent `<li>` tag and applied overflow-hidden on parent `<div>` to hide the last items overflowing underline (since there is border-radius given to parent)

## Screenshots

**Before :** 

![brighterBeginnings-issue-before](https://github.com/dakshsinghrathore/Brighter-Beginnings/assets/61643919/c937a7fb-bde6-4ecc-a0ca-1007ba2f696d)

**After:**

![brighterBeginnings-issue-after](https://github.com/dakshsinghrathore/Brighter-Beginnings/assets/61643919/dfcee2a6-5664-4667-9e5b-841b9dcfbdae)

