### PR TITLE
fix: Changed the Copyright Year to Current year

### DIFF
--- a/dist/development.html
+++ b/dist/development.html
@@ -548,7 +548,7 @@
             <p
               class="mt-4 text-center text-sm text-gray-500 sm:mt-0 sm:text-right"
             >
-              Copyright &copy; 2022. All rights reserved.
+              Copyright &copy; 2024. All rights reserved.
             </p>
           </div>
         </div>

--- a/dist/development.html
+++ b/dist/development.html
@@ -548,7 +548,7 @@
             <p
               class="mt-4 text-center text-sm text-gray-500 sm:mt-0 sm:text-right"
             >
-              Copyright &copy; 2024. All rights reserved.
+              Copyright &copy; <script>document.write(new Date().getFullYear())</script>. All rights reserved.
             </p>
           </div>
         </div>

--- a/dist/logic.html
+++ b/dist/logic.html
@@ -524,7 +524,7 @@
             <p
               class="mt-4 text-center text-sm text-gray-500 sm:mt-0 sm:text-right"
             >
-              Copyright &copy; 2024. All rights reserved.
+              Copyright &copy; <script>document.write(new Date().getFullYear())</script>. All rights reserved.
             </p>
           </div>
         </div>

--- a/dist/logic.html
+++ b/dist/logic.html
@@ -524,7 +524,7 @@
             <p
               class="mt-4 text-center text-sm text-gray-500 sm:mt-0 sm:text-right"
             >
-              Copyright &copy; 2022. All rights reserved.
+              Copyright &copy; 2024. All rights reserved.
             </p>
           </div>
         </div>

--- a/dist/problemsolving.html
+++ b/dist/problemsolving.html
@@ -1255,7 +1255,7 @@
             <p
               class="mt-4 text-center text-sm text-gray-500 sm:mt-0 sm:text-right"
             >
-              Copyright &copy; 2022. All rights reserved.
+              Copyright &copy; 2024. All rights reserved.
             </p>
           </div>
         </div>

--- a/dist/problemsolving.html
+++ b/dist/problemsolving.html
@@ -1255,7 +1255,7 @@
             <p
               class="mt-4 text-center text-sm text-gray-500 sm:mt-0 sm:text-right"
             >
-              Copyright &copy; 2024. All rights reserved.
+              Copyright &copy; <script>document.write(new Date().getFullYear())</script>. All rights reserved.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Related Issue

Issue #88

## Description

The Copyright Year is 2022 and I have Changed it to 2024. Only the Home page has the year 2024 and other pages like Problem Solving Have year 2022 so I have changed it to 2024.

## Screenshots

<!-- Add screenshots to preview the changes  -->

<img width="1315" alt="image" src="https://github.com/dakshsinghrathore/Brighter-Beginnings/assets/57393413/7970c047-cc7a-4a7e-9a6d-944531b60fff">
