### PR TITLE
[FIX] Options on get started page are fixed to full screen

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,24 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "no-inline-styles": "off",
+    "axe/name-role-value": [
+      "default",
+      {
+        "button-name": "off",
+        "link-name": "off"
+      }
+    ],
+    "button-type": "off",
+    "compat-api/css": [
+      "default",
+      {
+        "ignore": [
+          "text-underline-offset"
+        ]
+      }
+    ]
+  }
+}

--- a/dist/getstarted.html
+++ b/dist/getstarted.html
@@ -59,7 +59,7 @@
         </div>
       </header>
       <div
-        class="flex sm:mt-28 sm:items-center sm:justify-between md:px-0 md:py-0 w-screen justify-between flex-wrap md:flex-nowrap lg:flex-nowrap md:gap-0 lg:gap-0"
+        class="flex sm:mt-28 sm:items-center sm:justify-between md:px-0 md:py-0 w-full justify-between flex-wrap md:flex-nowrap lg:flex-nowrap md:gap-0 lg:gap-0"
       >
         <div class="flex w-full md:w-1/3 lg:w-1/3 py-6 px-8 md:px-6 lg:px-8">
           <a
@@ -70,13 +70,13 @@
               <img
                 src="../images/logic.png"
                 alt=""
-                class="absolute inset-0 w-80 object-cover transition duration-300 ease-in-out transform scale-100 group-hover:scale-90"
+                class="absolute inset-0 w-40 object-cover transition duration-300 ease-in-out transform scale-100 group-hover:scale-90"
               />
             </div>
           </a>
           <a
             href="logic.html"
-            class="mt-12 group block h-36 rounded-2xl w-36"
+            class="mt-12 group block h-18 rounded-2xl w-18"
           >
             <h2 class="text-center text-white font-bold text-3xl">
               Logic
@@ -120,7 +120,7 @@
           </a>
           <a
             href="development.html"
-            class="mt-12 group block h-36 rounded-2xl w-36"
+            class="mt-12 group block h-30 rounded-2xl w-30"
           >
             <h2 class="text-center text-white font-bold text-3xl">
               Development
@@ -142,7 +142,7 @@
           </a>
           <a
             href="advance-module.html"
-            class="mt-12 group block h-36 rounded-2xl w-36"
+            class="mt-12 group block h-32 rounded-2xl w-32"
           >
             <h2 class="text-center text-white font-bold text-3xl">
               Advance Module

--- a/dist/style.css
+++ b/dist/style.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&display=swap');
 
 /*
-! tailwindcss v3.3.5 | MIT License | https://tailwindcss.com
+
 */
 
 /*


### PR DESCRIPTION
## Related Issue
Options on getting started page were not properly showing 

## Description

The get started page has been fixed #150 
![image](https://github.com/dakshsinghrathore/Brighter-Beginnings/assets/115923314/c3f9ad9f-9b52-4d3a-8065-aef96374040b)

## Screenshots

<!-- Add screenshots to preview the changes  -->
![image](https://github.com/dakshsinghrathore/Brighter-Beginnings/assets/115923314/6f1df345-c96c-4136-872d-a625cb331401)

